### PR TITLE
fix(lib): Remove lib from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-lib
 tests
 .babelrc
 .eslintrc


### PR DESCRIPTION
The library isn't included if lib is in the npmignore file.