### PR TITLE
feat(api): Take a string for decryption instead of a filepath

### DIFF
--- a/lib/aws-secrets.js
+++ b/lib/aws-secrets.js
@@ -20,7 +20,7 @@ class AwsSecrets {
       if (target) {
         return fs.writeFileAsync(target, data.Plaintext.toString());
       }
-      return Promise.resolve(data.Plaintext.toString());
+      return data.Plaintext.toString();
     });
   }
 
@@ -32,26 +32,19 @@ class AwsSecrets {
     });
   }
 
-  static requireFromString(src) {
-    const Module = module.constructor;
-    const m = new Module();
-    m._compile(src, '');
-    return m.exports;
+  decrypt(encryptedString) {
+    const blob = new Buffer(encryptedString, 'base64');
+    return this.KMS.decrypt({ CiphertextBlob: blob }).promise()
+    .then(data => data.Plaintext.toString());
   }
 
-  req(filename) {
-    return this.decryptFile(`${filename}`)
-    .then((plaintext) => {
-      return AwsSecrets.requireFromString(plaintext);
-    })
-    // TODO: is this needed?
-    .then(m => m);
-  }
-
-  applySecrets(secretsFile, target) {
+  applySecrets(encryptedJsonSecrets, target) {
     const re = /^secrets@(.*)/;
-    return this.req(secretsFile)
+    return this.decrypt(encryptedJsonSecrets)
     .then((secrets) => {
+      if (!secrets) { return target; }
+
+      secrets = JSON.parse(secrets);
       // replace all secrets references with their values
       const newObj = _.cloneDeepWith(target, (v) => {
         if (_.isString(v)) {

--- a/tests/lib/aws-secrets.js
+++ b/tests/lib/aws-secrets.js
@@ -7,7 +7,7 @@ const mockFs = require('mock-fs');
 const AwsSecrets = require('../../lib/aws-secrets');
 
 const should = chai.should();
-const validSecretsObjectString = 'const x = { foo: \'bar\'}; module.exports.x = x;';
+const validSecretsObjectString = '{ "x": { "foo": "bar" } }';
 
 describe('AwsSecrets', () => {
   afterEach(mockFs.restore);
@@ -18,14 +18,6 @@ describe('AwsSecrets', () => {
         const awsSecrets = new AwsSecrets('asdf');
         should.exist(awsSecrets);
         awsSecrets.KeyId.should.equal('asdf');
-      });
-    });
-  });
-  describe('#requireFromString', () => {
-    describe('with valid module syntax', () => {
-      it('creates a valid object', () => {
-        const retval = AwsSecrets.requireFromString(validSecretsObjectString);
-        retval.should.deep.equal({ x: { foo: 'bar' } });
       });
     });
   });
@@ -70,13 +62,10 @@ describe('AwsSecrets', () => {
         const awsSecrets = new AwsSecrets('asdf', { region: 'eu-west-1' });
         simple.mock(awsSecrets.KMS, 'decrypt')
         .returnWith({ promise: () => P.resolve({ Plaintext: validSecretsObjectString }) });
-        mockFs({
-          x: 'asdf',
-        });
         const target = {
           x: 'secrets@x.foo',
         };
-        return awsSecrets.applySecrets('x', target)
+        return awsSecrets.applySecrets('asdf', target)
         .then((applied) => {
           applied.x.should.equal('bar');
         });
@@ -87,13 +76,10 @@ describe('AwsSecrets', () => {
         const awsSecrets = new AwsSecrets('asdf', { region: 'eu-west-1' });
         simple.mock(awsSecrets.KMS, 'decrypt')
         .returnWith({ promise: () => P.resolve({ Plaintext: '' }) });
-        mockFs({
-          x: 'asdf',
-        });
         const target = {
           x: 'secrets@x.foo',
         };
-        return awsSecrets.applySecrets('x', target)
+        return awsSecrets.applySecrets('asdf', target)
         .then((applied) => {
           applied.should.deep.equal(target);
         });
@@ -104,11 +90,9 @@ describe('AwsSecrets', () => {
         const awsSecrets = new AwsSecrets('asdf', { region: 'eu-west-1' });
         simple.mock(awsSecrets.KMS, 'decrypt')
         .returnWith({ promise: () => P.resolve({ Plaintext: validSecretsObjectString }) });
-        mockFs({
-          x: 'asdf',
-        });
+
         const target = {};
-        return awsSecrets.applySecrets('x', target)
+        return awsSecrets.applySecrets('asdf', target)
         .then((applied) => {
           applied.should.deep.equal(target);
         });
@@ -119,13 +103,11 @@ describe('AwsSecrets', () => {
         const awsSecrets = new AwsSecrets('asdf', { region: 'eu-west-1' });
         simple.mock(awsSecrets.KMS, 'decrypt')
         .returnWith({ promise: () => P.resolve({ Plaintext: validSecretsObjectString }) });
-        mockFs({
-          x: 'asdf',
-        });
+
         const target = {
           x: 'secrets@x.foos',
         };
-        return awsSecrets.applySecrets('x', target)
+        return awsSecrets.applySecrets('asdf', target)
         .then((applied) => {
           applied.should.deep.equal(target);
         });


### PR DESCRIPTION
Requiring access to the filesystem in this package is unnecessarily restrictive. Users may want to
store their encrypted strings elsewhere, or use something like webpack or browserify, which changes
how the encrypted string is retrieved.

Apply secrets now takes the base64 encoded string as input, not a filepath.