### PR TITLE
Adding ability to specify region via command line

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,9 +8,15 @@ const { command, argv } = commandLineCommands(validCommands);
 
 const options = commandLineArgs([
   { name: 'key', alias: 'k', type: String },
+  { name: 'region', alias: 'r', type: String },
 ]);
 
-const awsSecrets = new AwsSecrets(options.key);
+let awsSecrets;
+if (options.region){
+  awsSecrets = new AwsSecrets(options.key, { region: options.region });
+} else {
+  awsSecrets = new AwsSecrets(options.key);
+}
 switch (command.toLowerCase()) {
   case 'encrypt-file':
     awsSecrets.encryptFile(argv[0], argv[1]);

--- a/tests/lib/aws-secrets.js
+++ b/tests/lib/aws-secrets.js
@@ -20,6 +20,13 @@ describe('AwsSecrets', () => {
         awsSecrets.KeyId.should.equal('asdf');
       });
     });
+    describe('with specified region', () => {
+      it('uses the provided region', () => {
+        const awsSecrets = new AwsSecrets('asdf', { region: 'eu-west-1' });
+        should.exist(awsSecrets);
+        awsSecrets.KMS.config.region.should.equal('eu-west-1');
+      })
+    })
   });
   describe('#decryptFile', () => {
     describe('with encrypted data and no target', () => {


### PR DESCRIPTION
This is to allow us to invoke aws-secret commands in jenkins without setting up environment variables